### PR TITLE
Remove dependencies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@
 
 name:                ipgenerator
 version:             0.1.0.0
-license:             Apache2
+license:             Apache-2.0
 author:              "Author name here"
 maintainer:          "izaak.weiss@gmail.com"
 copyright:           "Google LLC"
@@ -23,21 +23,17 @@ copyright:           "Google LLC"
 extra-source-files:
 - README.md
 
-description:         A pair of command line utilities used to 
+description:         A pair of command line utilities used to
 
 dependencies:
 - base >= 4.7 && < 5
 - random
 - text
-- QuickCheck
 - turtle
 
 library:
   source-dirs: src
   ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
     - -Wall
     - -Werror
 
@@ -76,7 +72,9 @@ tests:
     - -with-rtsopts=-N
     - -Wall
     - -Werror
+    - -fno-warn-orphans
     dependencies:
     - ipgenerator
     - hspec
     - split
+    - QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,7 @@ dependencies:
 - base >= 4.7 && < 5
 - random
 - text
-- turtle
+- split
 
 library:
   source-dirs: src
@@ -76,5 +76,4 @@ tests:
     dependencies:
     - ipgenerator
     - hspec
-    - split
     - QuickCheck

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -20,8 +20,6 @@ import           Data.List
 import           System.Random
 import qualified Data.Text as T
 
-import Test.QuickCheck (Arbitrary, arbitrary)
-
 ----------------------
 -- * Data Structures
 ----------------------
@@ -255,27 +253,3 @@ parseMask :: T.Text -> (Mask, Format)
 parseMask t = case T.head t of
   '/' -> (Mask $ readText $ T.tail t, Cidr)
   _ -> (Mask $ sum $ map (invResidual . readText) $ T.splitOn "." t, Binary)
-
---------------
--- * Testing
---------------
-
-instance Arbitrary Mask where
-  arbitrary = Mask . (+8) . (flip mod 24) <$> arbitrary
-
-instance Arbitrary Ipv4 where
-  arbitrary = Octets <$> ab <*> ab <*> ab <*> ab
-    where ab = flip mod 256 <$> arbitrary
-
-newtype ArbA = ArbA (Ipv4, Mask) deriving (Eq, Show)
-newtype ArbB = ArbB (Ipv4, Mask) deriving (Eq, Show)
-newtype ArbC = ArbC (Ipv4, Mask) deriving (Eq, Show)
-
-instance Arbitrary ArbA where
-  arbitrary = ArbA <$> (mkA <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)
-
-instance Arbitrary ArbB where
-  arbitrary = ArbB <$> (mkB <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)
-
-instance Arbitrary ArbC where
-  arbitrary = ArbC <$> (mkC <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -18,9 +18,8 @@ import Test.QuickCheck (Arbitrary, arbitrary)
 
 import Control.Monad
 import Data.Char
-import Data.List.Split
 import Data.Maybe
-import qualified Data.Text as T
+import Data.List.Split
 
 import Lib
 
@@ -183,14 +182,22 @@ main = hspec $ do
 
   describe "parseIP" $ do
     it "is the inverse of IP's show" $ do
-      property (\i -> parseIP (T.pack $ show i) == i)
+      property (\i -> parseIP (show i) == Just i)
+
+    -- How flaky will this be?
+    it "chokes on random strings" $ do
+      property (\s -> parseIP s == Nothing)
 
   describe "parseMask" $ do
     it "is the inverse of Slash's show" $ do
-      property (\m -> parseMask (T.pack $ show $ Slash m) == (m, Cidr))
+      property (\m -> parseMask (show $ Slash m) == Just (m, Cidr))
 
     it "is the inverse of Bits's show" $ do
-      property (\m -> parseMask (T.pack $ show $ Bits m) == (m, Binary))
+      property (\m -> parseMask (show $ Bits m) == Just (m, Binary))
+
+    -- How flaky will this be?
+    it "chokes on random strings" $ do
+      property (\s -> parseMask s == Nothing)
 
   -- Generator Functions
 


### PR DESCRIPTION
This removes turtle, quickcheck, and text from the dependencies of the release binaries. It adds split, but that is a considerably smaller amount of code.